### PR TITLE
fix: file selector not triggered when clicking padding area

### DIFF
--- a/src/components/Synthesis/index.tsx
+++ b/src/components/Synthesis/index.tsx
@@ -8,8 +8,12 @@ import {
   Form,
   Input,
 } from "@heroui/react";
+import { useRef } from "react";
 
 const Synthesis = () => {
+  const keyboardFileRef = useRef<HTMLInputElement>(null);
+  const handFileRef = useRef<HTMLInputElement>(null);
+
   return (
     <Form>
       <Card>
@@ -20,9 +24,23 @@ const Synthesis = () => {
         <Divider />
 
         <CardBody className="flex flex-col gap-4">
-          <Input isRequired label="键盘" name="keyboard" type="file" />
+          <Input
+            isRequired
+            label="键盘"
+            name="keyboard"
+            onFocus={() => keyboardFileRef.current?.click()}
+            ref={keyboardFileRef}
+            type="file"
+          />
 
-          <Input isRequired label="手部" name="hand" type="file" />
+          <Input
+            isRequired
+            label="手部"
+            name="hand"
+            onFocus={() => handFileRef.current?.click()}
+            ref={handFileRef}
+            type="file"
+          />
         </CardBody>
 
         <Divider />


### PR DESCRIPTION
![图片](https://github.com/user-attachments/assets/d7906265-eb52-4cbc-8db6-cab490b0d20b)

修复了点击绿色padding区域不会触发文件选择器