### PR TITLE
perf: skip toast on abort

### DIFF
--- a/src/components/Converter/index.tsx
+++ b/src/components/Converter/index.tsx
@@ -89,6 +89,8 @@ const Converter = () => {
 
       setHandles(handles);
     } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") return;
+
       addToast({
         color: "danger",
         title: String(error),


### PR DESCRIPTION
![](https://github.com/user-attachments/assets/722198ee-bd6d-4eba-89df-fd65deb0e533)

取消文件选择时, 不显示错误提示